### PR TITLE
Make EventState immutable.

### DIFF
--- a/src/main/java/no/fint/provider/events/eventstate/EventState.java
+++ b/src/main/java/no/fint/provider/events/eventstate/EventState.java
@@ -2,38 +2,26 @@ package no.fint.provider.events.eventstate;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
 import no.fint.event.model.Event;
 
 import java.io.Serializable;
+import java.util.concurrent.TimeUnit;
 
 @Data
-@NoArgsConstructor
 @EqualsAndHashCode(of = "corrId")
 public class EventState implements Serializable {
-    private String corrId;
-    private long expires;
+    private final String corrId;
+    private final long expires;
+    private final Event event;
 
-    private Event event;
-
-    public EventState(Event event) {
-        this.corrId = event.getCorrId();
+    public EventState(Event event, int timeToLiveMinutes) {
         this.event = event;
-    }
-
-    public EventState(Event event, int timeToLiveMintues) {
-        updateTtl(timeToLiveMintues);
-        if (event != null) {
-            this.corrId = event.getCorrId();
-            this.event = event;
-        }
+        corrId = event.getCorrId();
+        expires = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(timeToLiveMinutes);
     }
 
     public boolean expired() {
         return (System.currentTimeMillis() > expires);
     }
 
-    public void updateTtl(int timeToLiveMinutes) {
-        expires = System.currentTimeMillis() + (timeToLiveMinutes * 60 * 1000);
-    }
 }

--- a/src/main/java/no/fint/provider/events/eventstate/EventStateService.java
+++ b/src/main/java/no/fint/provider/events/eventstate/EventStateService.java
@@ -1,19 +1,16 @@
 package no.fint.provider.events.eventstate;
 
-import java.util.Optional;
-import java.util.Set;
-
-import javax.annotation.PostConstruct;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
 import com.hazelcast.core.HazelcastInstance;
-
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import no.fint.event.model.Event;
 import no.fint.provider.events.ProviderProps;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import java.util.Optional;
+import java.util.Set;
 
 @Slf4j
 @Service
@@ -41,7 +38,7 @@ public class EventStateService {
         return eventStates.stream().filter(eventState -> eventState.getCorrId().equals(event.getCorrId())).findAny();
     }
 
-    public void remove(Event event) {
+    public Optional<EventState> remove(Event event) {
         Optional<EventState> eventState = get(event);
         if (eventState.isPresent()) {
             boolean removed = eventStates.remove(eventState.get());
@@ -49,6 +46,7 @@ public class EventStateService {
                 log.warn("Unable to remove event with corrId {} from EventStates", event.getCorrId());
             }
         }
+        return eventState;
     }
 
 }

--- a/src/main/java/no/fint/provider/events/status/StatusService.java
+++ b/src/main/java/no/fint/provider/events/status/StatusService.java
@@ -31,19 +31,17 @@ public class StatusService {
     private ProviderProps providerProps;
 
     public void updateEventState(Event event) {
-        Optional<EventState> state = eventStateService.get(event);
+        Optional<EventState> state = eventStateService.remove(event);
         if (state.isPresent()) {
             fintAuditService.audit(event);
             EventState eventState = state.get();
 
             if (event.getStatus() == Status.ADAPTER_ACCEPTED) {
-                eventState.updateTtl(providerProps.getResponseTtl());
+                eventStateService.add(event, providerProps.getResponseTtl());
             } else {
                 log.info("Adapter did not acknowledge the event (status: {}), sending event upstream.", event.getStatus().name());
                 event.setMessage(String.format("Adapter did not acknowledge the event (status: %s)", event.getStatus().name()));
-                fintAuditService.audit(event);
                 fintEvents.sendUpstream(event);
-                eventStateService.remove(event);
             }
         } else {
             log.error("EventState with corrId {} was not found. Either the Event has expired or the provider does not recognize the corrId. {}", event.getCorrId(), event);

--- a/src/test/groovy/no/fint/provider/events/eventstate/EventStateControllerSpec.groovy
+++ b/src/test/groovy/no/fint/provider/events/eventstate/EventStateControllerSpec.groovy
@@ -1,5 +1,6 @@
 package no.fint.provider.events.eventstate
 
+import no.fint.event.model.Event
 import no.fint.test.utils.MockMvcSpecification
 import org.springframework.test.web.servlet.MockMvc
 
@@ -19,7 +20,7 @@ class EventStateControllerSpec extends MockMvcSpecification {
         def response = mockMvc.perform(get('/eventStates'))
 
         then:
-        1 * eventStateService.getEventStates() >> [new EventState()]
+        1 * eventStateService.getEventStates() >> [new EventState(new Event(), 42)]
         response.andExpect(status().isOk())
                 .andExpect(jsonPath('$', hasSize(1)))
     }

--- a/src/test/groovy/no/fint/provider/events/eventstate/EventStateSpec.groovy
+++ b/src/test/groovy/no/fint/provider/events/eventstate/EventStateSpec.groovy
@@ -10,15 +10,6 @@ class EventStateSpec extends Specification {
         event = new Event('rogfk.no', 'FK', 'GET', 'client')
     }
 
-    def "Create EventState Object"() {
-        when:
-        def eventState = new EventState(event)
-
-        then:
-        eventState.corrId != null
-        eventState.event == event
-    }
-
     def "Create EventState object with ttl"() {
         when:
         def eventState = new EventState(event, 2)
@@ -30,15 +21,4 @@ class EventStateSpec extends Specification {
         !eventState.expired()
     }
 
-    def "Update ttl on existing EventState"() {
-        given:
-        def eventState = new EventState(event, 2)
-
-        when:
-        def originalTtl = eventState.expires
-        eventState.updateTtl(3)
-
-        then:
-        eventState.expires > originalTtl
-    }
 }

--- a/src/test/groovy/no/fint/provider/events/eventstate/JanitorServiceSpec.groovy
+++ b/src/test/groovy/no/fint/provider/events/eventstate/JanitorServiceSpec.groovy
@@ -18,10 +18,8 @@ class JanitorServiceSpec extends Specification {
     def "Remove expired event states"() {
         given:
         def event = new Event(orgId: 'rogfk.no')
-        def expiredTimestamp = System.currentTimeMillis() - 10
-        def notExpiredTimestamp = System.currentTimeMillis() + 5000
-        def expiredEventState = new EventState(corrId: '123', event: event, expires: expiredTimestamp)
-        def notExpiredEventState = new EventState(corrId: '234', event: event, expires: notExpiredTimestamp)
+        def expiredEventState = new EventState(event, -10)
+        def notExpiredEventState = new EventState(event, 5000)
 
         when:
         janitorService.cleanUpEventStates()

--- a/src/test/groovy/no/fint/provider/events/eventstate/JanitorServiceSpec.groovy
+++ b/src/test/groovy/no/fint/provider/events/eventstate/JanitorServiceSpec.groovy
@@ -27,5 +27,6 @@ class JanitorServiceSpec extends Specification {
         then:
         1 * eventStateService.getEventStates() >> [expiredEventState, notExpiredEventState]
         1 * eventStateService.remove(_ as Event)
+        1 * fintAuditService.audit(_ as Event)
     }
 }

--- a/src/test/groovy/no/fint/provider/events/response/ResponseServiceSpec.groovy
+++ b/src/test/groovy/no/fint/provider/events/response/ResponseServiceSpec.groovy
@@ -39,7 +39,7 @@ class ResponseServiceSpec extends Specification {
         responseService.handleAdapterResponse(event)
 
         then:
-        1 * eventStateService.get(event) >> Optional.of(new EventState())
+        1 * eventStateService.get(event) >> Optional.of(new EventState(event, 10))
         1 * fintEvents.sendUpstream(event)
         1 * eventStateService.remove(event)
     }


### PR DESCRIPTION
With EventStateService using Hazelcast, updating TTL on the EventState object directly has no effect.

This PR changes EventState to be an immutable object, replacing it with a new instance when StatusService needs to update TTL.