### PR TITLE
Added x-client request header to SSE subscription.

### DIFF
--- a/src/main/java/no/fint/provider/events/sse/FintSseEmitter.java
+++ b/src/main/java/no/fint/provider/events/sse/FintSseEmitter.java
@@ -13,6 +13,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 @EqualsAndHashCode(callSuper = true)
 public class FintSseEmitter extends SseEmitter {
     private String id;
+    private String client;
     private String registered;
     private final AtomicInteger eventCounter = new AtomicInteger();
 
@@ -20,9 +21,10 @@ public class FintSseEmitter extends SseEmitter {
         setRegisteredDate();
     }
 
-    public FintSseEmitter(String id, long timeout) {
+    public FintSseEmitter(String id, String client, long timeout) {
         super(timeout);
         this.id = id;
+        this.client = client;
         setRegisteredDate();
     }
 

--- a/src/main/java/no/fint/provider/events/sse/SseClient.java
+++ b/src/main/java/no/fint/provider/events/sse/SseClient.java
@@ -8,5 +8,6 @@ import lombok.Data;
 public class SseClient {
     private String registered;
     private String id;
+    private String client;
     private int events;
 }

--- a/src/main/java/no/fint/provider/events/sse/SseController.java
+++ b/src/main/java/no/fint/provider/events/sse/SseController.java
@@ -36,8 +36,10 @@ public class SseController {
     @Synchronized
     @GetMapping("/{id}")
     public SseEmitter subscribe(@ApiParam(Constants.SWAGGER_X_ORG_ID) @RequestHeader(HeaderConstants.ORG_ID) String orgId,
+                                @ApiParam("ID of client.") @RequestHeader(HeaderConstants.CLIENT) String client,
                                 @ApiParam("Global unique id for the client. Typically a UUID.") @PathVariable String id) {
-        SseEmitter emitter = sseService.subscribe(id, orgId);
+        log.info("{}: Client {}, ID {}", orgId, client, id);
+        SseEmitter emitter = sseService.subscribe(id, orgId, client);
         fintEvents.registerDownstreamListener(orgId, downstreamSubscriber);
         return emitter;
     }
@@ -49,7 +51,7 @@ public class SseController {
         List<SseOrg> orgs = new ArrayList<>();
         clients.forEach((key, value) -> {
             List<SseClient> sseClients = new ArrayList<>();
-            value.forEach(emitter -> sseClients.add(new SseClient(emitter.getRegistered(), emitter.getId(), emitter.getEventCounter().get())));
+            value.forEach(emitter -> sseClients.add(new SseClient(emitter.getRegistered(), emitter.getId(), emitter.getClient(), emitter.getEventCounter().get())));
 
             orgs.add(new SseOrg(key, sseClients));
         });

--- a/src/main/java/no/fint/provider/events/sse/SseService.java
+++ b/src/main/java/no/fint/provider/events/sse/SseService.java
@@ -28,7 +28,7 @@ public class SseService {
     }
 
     @Synchronized
-    public SseEmitter subscribe(String id, String orgId) {
+    public SseEmitter subscribe(String id, String orgId, String client) {
         FintSseEmitters fintSseEmitters = clients.get(orgId);
         if (fintSseEmitters == null) {
             fintSseEmitters = FintSseEmitters.with(providerProps.getMaxNumberOfEmitters(), this::closeEmitter);
@@ -38,11 +38,11 @@ public class SseService {
         if (registeredEmitter.isPresent()) {
             return registeredEmitter.get();
         } else {
-            log.info("id: {}, {} connected", id, orgId);
-            FintSseEmitter emitter = new FintSseEmitter(id,
+            log.info("{}: {} connected", orgId, id);
+            FintSseEmitter emitter = new FintSseEmitter(id, client,
                     TimeUnit.MINUTES.toMillis(
                             ThreadLocalRandom.current().nextInt(2000) +
-                            providerProps.getSseTimeoutMinutes()));
+                                    providerProps.getSseTimeoutMinutes()));
             emitter.onCompletion(() -> {
                 log.info("onCompletion called for {}, id: {}", orgId, emitter.getId());
                 removeEmitter(orgId, emitter);

--- a/src/test/groovy/no/fint/provider/events/sse/FintSseEmitterSpec.groovy
+++ b/src/test/groovy/no/fint/provider/events/sse/FintSseEmitterSpec.groovy
@@ -6,7 +6,7 @@ class FintSseEmitterSpec extends Specification {
 
     def "Create new FintSseEmitter"() {
         when:
-        def fintSseEmitter = new FintSseEmitter('123', 123)
+        def fintSseEmitter = new FintSseEmitter('123', 'client', 123)
 
         then:
         fintSseEmitter.id == '123'

--- a/src/test/groovy/no/fint/provider/events/sse/SseControllerSpec.groovy
+++ b/src/test/groovy/no/fint/provider/events/sse/SseControllerSpec.groovy
@@ -23,17 +23,19 @@ class SseControllerSpec extends MockMvcSpecification {
 
     def "Subscribe to sse client"() {
         when:
-        def response = mockMvc.perform(get('/sse/123').header(HeaderConstants.ORG_ID, 'rogfk.no'))
+        def response = mockMvc.perform(get('/sse/123')
+                .header(HeaderConstants.ORG_ID, 'rogfk.no')
+                .header(HeaderConstants.CLIENT, 'client'))
 
         then:
-        1 * sseService.subscribe('123', 'rogfk.no')
+        1 * sseService.subscribe('123', 'rogfk.no', 'client')
         1 * fintEvents.registerDownstreamListener('rogfk.no', downstreamSubscriber)
         response.andExpect(status().isOk())
     }
 
     def "Get registered sse clients"() {
         given:
-        def emitter = new FintSseEmitter('123', 1000)
+        def emitter = new FintSseEmitter('123', 'client', 1000)
         def emitters = new FintSseEmitters(1, null)
         emitters.add(emitter)
 

--- a/src/test/groovy/no/fint/provider/events/sse/SseServiceSpec.groovy
+++ b/src/test/groovy/no/fint/provider/events/sse/SseServiceSpec.groovy
@@ -20,7 +20,7 @@ class SseServiceSpec extends Specification {
 
     def "Return SseEmitter when subscribing with new orgId"() {
         when:
-        def emitter = sseService.subscribe('123', 'hfk.no')
+        def emitter = sseService.subscribe('123', 'hfk.no', 'client')
 
         then:
         emitter != null
@@ -29,8 +29,8 @@ class SseServiceSpec extends Specification {
 
     def "Return new SseEmitter when subscribing with already registered orgId"() {
         when:
-        def emitter1 = sseService.subscribe('123', 'hfk.no')
-        def emitter2 = sseService.subscribe('234', 'hfk.no')
+        def emitter1 = sseService.subscribe('123', 'hfk.no', 'client')
+        def emitter2 = sseService.subscribe('234', 'hfk.no', 'client')
 
         then:
         sseService.getSseClients().size() == 1
@@ -40,7 +40,7 @@ class SseServiceSpec extends Specification {
     def "Send Event to registered emitter"() {
         given:
         def event = new Event('hfk.no', 'FK', 'GET_ALL_EMPLOYEES', 'test')
-        sseService.subscribe('123', 'hfk.no')
+        sseService.subscribe('123', 'hfk.no', 'client')
 
         when:
         sseService.send(event)


### PR DESCRIPTION
This PR adds `x-client` as a required header for the `/sse/{id}` endpoint, and tracks the value for reporting active SSE clients.

It depends on Access Gateway configuration for injecting this header based on OAuth claims, and does not require adapters to provide this header.