### PR TITLE
Dynamic assetIDs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,8 +45,8 @@ repositories {
 
 dependencies {
     compile('no.fint:fint-audit-mongo-plugin:1.4.1')
-    compile('no.fint:fint-events:2.1.0-rc-1')
-    compile('no.fint:fint-event-model:2.0.1')
+    compile('no.fint:fint-events:2.2.0-rc-1')
+    compile('no.fint:fint-event-model:3.0.0')
     compile('no.fint:fint-springfox-extension:0.0.1')
 
     compile('org.projectlombok:lombok')

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Thu Sep 27 15:48:07 CEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip

--- a/src/main/java/no/fint/provider/events/admin/AdminController.java
+++ b/src/main/java/no/fint/provider/events/admin/AdminController.java
@@ -82,7 +82,7 @@ public class AdminController {
             @ApiParam(Constants.SWAGGER_X_ORG_ID) @PathVariable String orgId,
             @ApiParam("ID of client.") @RequestHeader(HeaderConstants.CLIENT) String client) {
         if (adminService.isRegistered(orgId)) {
-            return ResponseEntity.badRequest().body(String.format("OrgId %s is already registered", orgId));
+            return ResponseEntity.noContent().build();
         } else if (adminService.register(orgId, client)) {
             fintEvents.registerDownstreamListener(orgId, downstreamSubscriber);
             URI location = ServletUriComponentsBuilder.fromCurrentRequest().buildAndExpand().toUri();

--- a/src/main/java/no/fint/provider/events/admin/AdminController.java
+++ b/src/main/java/no/fint/provider/events/admin/AdminController.java
@@ -5,6 +5,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiParam;
 import lombok.extern.slf4j.Slf4j;
 import no.fint.audit.plugin.mongo.MongoAuditEvent;
+import no.fint.event.model.HeaderConstants;
 import no.fint.events.FintEvents;
 import no.fint.provider.events.Constants;
 import no.fint.provider.events.subscriber.DownstreamSubscriber;
@@ -12,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -76,15 +78,17 @@ public class AdminController {
     }
 
     @PostMapping("/orgIds/{orgId}")
-    public ResponseEntity registerOrgId(@ApiParam(Constants.SWAGGER_X_ORG_ID) @PathVariable String orgId) {
+    public ResponseEntity registerOrgId(
+            @ApiParam(Constants.SWAGGER_X_ORG_ID) @PathVariable String orgId,
+            @ApiParam("ID of client.") @RequestHeader(HeaderConstants.CLIENT) String client) {
         if (adminService.isRegistered(orgId)) {
             return ResponseEntity.badRequest().body(String.format("OrgId %s is already registered", orgId));
-        } else {
+        } else if (adminService.register(orgId, client)) {
             fintEvents.registerDownstreamListener(orgId, downstreamSubscriber);
-            adminService.register(orgId);
-
             URI location = ServletUriComponentsBuilder.fromCurrentRequest().buildAndExpand().toUri();
             return ResponseEntity.created(location).build();
+        } else {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Unauthorized orgId " + orgId);
         }
     }
 }

--- a/src/main/java/no/fint/provider/events/admin/AdminController.java
+++ b/src/main/java/no/fint/provider/events/admin/AdminController.java
@@ -65,7 +65,7 @@ public class AdminController {
         )).collect(Collectors.toList());
     }
 
-    @GetMapping("/orgIds/{orgId}")
+    @GetMapping("/orgIds/{orgId:.+}")
     public ResponseEntity getOrganization(@ApiParam(Constants.SWAGGER_X_ORG_ID) @PathVariable String orgId) {
         if (adminService.isRegistered(orgId)) {
             return ResponseEntity.ok(ImmutableMap.of(
@@ -77,7 +77,7 @@ public class AdminController {
         }
     }
 
-    @PostMapping("/orgIds/{orgId}")
+    @PostMapping("/orgIds/{orgId:.+}")
     public ResponseEntity registerOrgId(
             @ApiParam(Constants.SWAGGER_X_ORG_ID) @PathVariable String orgId,
             @ApiParam("ID of client.") @RequestHeader(HeaderConstants.CLIENT) String client) {

--- a/src/main/java/no/fint/provider/events/admin/AdminDownstreamSubscriber.java
+++ b/src/main/java/no/fint/provider/events/admin/AdminDownstreamSubscriber.java
@@ -21,7 +21,7 @@ public class AdminDownstreamSubscriber implements FintEventListener {
 
     @PostConstruct
     public void init() {
-        fintEvents.registerDownstreamListener("system", this);
+        fintEvents.registerDownstreamSystemListener( this);
     }
 
     @Override
@@ -29,7 +29,7 @@ public class AdminDownstreamSubscriber implements FintEventListener {
         if (event.isRegisterOrgId()) {
             adminService.register(event.getOrgId(), event.getClient());
         } else {
-            log.error("Cannot process event action {} with system orgId", event.getAction());
+            log.error("Cannot process system event {}", event.getAction());
         }
     }
 }

--- a/src/main/java/no/fint/provider/events/admin/AdminDownstreamSubscriber.java
+++ b/src/main/java/no/fint/provider/events/admin/AdminDownstreamSubscriber.java
@@ -27,7 +27,7 @@ public class AdminDownstreamSubscriber implements FintEventListener {
     @Override
     public void accept(Event event) {
         if (event.isRegisterOrgId()) {
-            adminService.register(event.getOrgId());
+            adminService.register(event.getOrgId(), event.getClient());
         } else {
             log.error("Cannot process event action {} with system orgId", event.getAction());
         }

--- a/src/main/java/no/fint/provider/events/admin/AdminService.java
+++ b/src/main/java/no/fint/provider/events/admin/AdminService.java
@@ -2,6 +2,10 @@ package no.fint.provider.events.admin;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import no.fint.event.model.DefaultActions;
+import no.fint.event.model.Event;
+import no.fint.events.FintEvents;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.Map;
@@ -10,6 +14,9 @@ import java.util.concurrent.ConcurrentHashMap;
 @Slf4j
 @Service
 public class AdminService {
+
+    @Autowired
+    private FintEvents fintEvents;
 
     @Getter
     private Map<String, Long> orgIds = new ConcurrentHashMap<>();
@@ -22,11 +29,15 @@ public class AdminService {
         return orgIds.containsKey(orgId);
     }
 
-    public void register(String orgId) {
+    public boolean register(String orgId, String client) {
         if (isRegistered(orgId)) {
             log.warn("OrgId {} is already registered, skipping new registration", orgId);
+            return true;
         } else {
+            Event e = new Event(orgId, "provider", DefaultActions.REGISTER_ORG_ID, client);
+            fintEvents.sendUpstream(e);
             orgIds.put(orgId, System.currentTimeMillis());
+            return true;
         }
     }
 }

--- a/src/main/java/no/fint/provider/events/admin/AdminService.java
+++ b/src/main/java/no/fint/provider/events/admin/AdminService.java
@@ -6,10 +6,19 @@ import no.fint.event.model.DefaultActions;
 import no.fint.event.model.Event;
 import no.fint.events.FintEvents;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
 
 @Slf4j
 @Service
@@ -18,6 +27,26 @@ public class AdminService {
     @Autowired
     private FintEvents fintEvents;
 
+    private RestTemplate restTemplate = new RestTemplate();
+
+    @Value("${fint.provider.assets.endpoint:}")
+    private String assetsEndpoint;
+
+    @Value("${fint.events.orgIds:}")
+    private volatile String[] validAssets;
+
+    @Scheduled(initialDelay = 1, fixedRateString = "${fint.provider.assets.rate:3600000}")
+    public void refreshAssets() {
+        if (StringUtils.isEmpty(assetsEndpoint))
+            return;
+        try {
+            validAssets = restTemplate.getForObject(assetsEndpoint, String[].class);
+            log.info("Valid assets: {}", Arrays.toString(validAssets));
+        } catch (RestClientException e) {
+            log.info("Unable to fetch valid assets from {}: {}", assetsEndpoint, e);
+        }
+    }
+
     @Getter
     private Map<String, Long> orgIds = new ConcurrentHashMap<>();
 
@@ -25,17 +54,14 @@ public class AdminService {
         return orgIds.get(orgId);
     }
 
-    // TODO This is not safe - a restarted consumer needs to get re-registered.
-    @Deprecated
     public boolean isRegistered(String orgId) {
         return orgIds.containsKey(orgId);
     }
 
-    // TODO Validation towards fint-admin-portal for enabled orgIds.
     public boolean register(String orgId, String client) {
-        if (isRegistered(orgId)) {
-            log.warn("OrgId {} is already registered, skipping new registration", orgId);
-            return true;
+        if (!isRegistered(orgId) && validAssets != null && Stream.of(validAssets).noneMatch(orgId::equals)) {
+            log.warn("OrgId {} is not enabled!", orgId);
+            return false;
         } else {
             Event e = new Event(orgId, "provider", DefaultActions.REGISTER_ORG_ID, client);
             fintEvents.sendUpstream(e);

--- a/src/main/java/no/fint/provider/events/admin/AdminService.java
+++ b/src/main/java/no/fint/provider/events/admin/AdminService.java
@@ -10,12 +10,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
-import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
@@ -39,12 +36,8 @@ public class AdminService {
     public void refreshAssets() {
         if (StringUtils.isEmpty(assetsEndpoint))
             return;
-        try {
-            validAssets = restTemplate.getForObject(assetsEndpoint, String[].class);
-            log.info("Valid assets: {}", Arrays.toString(validAssets));
-        } catch (RestClientException e) {
-            log.info("Unable to fetch valid assets from {}: {}", assetsEndpoint, e);
-        }
+        validAssets = restTemplate.getForObject(assetsEndpoint, String[].class);
+        log.info("Valid assets: {}", Arrays.toString(validAssets));
     }
 
     @Getter

--- a/src/main/java/no/fint/provider/events/admin/AdminService.java
+++ b/src/main/java/no/fint/provider/events/admin/AdminService.java
@@ -25,10 +25,13 @@ public class AdminService {
         return orgIds.get(orgId);
     }
 
+    // TODO This is not safe - a restarted consumer needs to get re-registered.
+    @Deprecated
     public boolean isRegistered(String orgId) {
         return orgIds.containsKey(orgId);
     }
 
+    // TODO Validation towards fint-admin-portal for enabled orgIds.
     public boolean register(String orgId, String client) {
         if (isRegistered(orgId)) {
             log.warn("OrgId {} is already registered, skipping new registration", orgId);

--- a/src/main/java/no/fint/provider/events/response/ResponseService.java
+++ b/src/main/java/no/fint/provider/events/response/ResponseService.java
@@ -1,7 +1,5 @@
 package no.fint.provider.events.response;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import lombok.extern.slf4j.Slf4j;
 import no.fint.audit.FintAuditService;
 import no.fint.event.model.Event;
@@ -11,25 +9,14 @@ import no.fint.provider.events.eventstate.EventState;
 import no.fint.provider.events.eventstate.EventStateService;
 import no.fint.provider.events.exceptions.UnknownEventException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.util.List;
 import java.util.Optional;
 
 @Slf4j
 @Service
 public class ResponseService {
-
-    @Value("${fint.provider.tracing:false}")
-    private boolean tracing;
 
     @Autowired
     private EventStateService eventStateService;
@@ -40,39 +27,10 @@ public class ResponseService {
     @Autowired
     private FintEvents fintEvents;
 
-    private Path traceFile;
-    private ObjectMapper objectMapper;
-
-    @PostConstruct
-    public void init() throws IOException {
-        if (tracing) {
-            traceFile = Files.createTempFile("response", ".json");
-            Files.write(traceFile, "[\n{}".getBytes());
-            objectMapper = new ObjectMapper().disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
-            log.info("Tracing response events to {}", traceFile.toAbsolutePath());
-        }
-    }
-
-    @PreDestroy
-    public void shutdown() throws IOException {
-        if (tracing)
-            try (OutputStream os = Files.newOutputStream(traceFile, StandardOpenOption.APPEND, StandardOpenOption.SYNC)) {
-                os.write("\n]\n".getBytes());
-            }
-    }
-
     public void handleAdapterResponse(Event event) {
         log.debug("{}: Response for {} from {} status {} with {} elements.",
                 event.getCorrId(), event.getAction(), event.getOrgId(), event.getStatus(),
                 Optional.ofNullable(event.getData()).map(List::size).orElse(0));
-        if (tracing) {
-            try (OutputStream os = Files.newOutputStream(traceFile, StandardOpenOption.APPEND, StandardOpenOption.SYNC)){
-                os.write(",\n".getBytes());
-                objectMapper.writeValue(os, event);
-            } catch (IOException e) {
-                log.info("Unable to trace event", e);
-            }
-        }
         if (event.isHealthCheck()) {
             event.setStatus(Status.UPSTREAM_QUEUE);
             fintEvents.sendUpstream(event);

--- a/src/main/java/no/fint/provider/events/sse/SseController.java
+++ b/src/main/java/no/fint/provider/events/sse/SseController.java
@@ -11,10 +11,12 @@ import no.fint.provider.events.Constants;
 import no.fint.provider.events.admin.AdminService;
 import no.fint.provider.events.subscriber.DownstreamSubscriber;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -76,4 +78,8 @@ public class SseController {
     public void authorize() {
     }
 
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity handleIllegalArgumentException(Exception e) {
+        return ResponseEntity.badRequest().body(Collections.singletonMap("error", e.getMessage()));
+    }
 }

--- a/src/main/java/no/fint/provider/events/subscriber/DownstreamSubscriber.java
+++ b/src/main/java/no/fint/provider/events/subscriber/DownstreamSubscriber.java
@@ -1,7 +1,5 @@
 package no.fint.provider.events.subscriber;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import lombok.extern.slf4j.Slf4j;
 import no.fint.audit.FintAuditService;
 import no.fint.event.model.Event;
@@ -14,23 +12,11 @@ import no.fint.provider.events.ProviderProps;
 import no.fint.provider.events.eventstate.EventStateService;
 import no.fint.provider.events.sse.SseService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 
 @Slf4j
 @Component
 public class DownstreamSubscriber implements FintEventListener {
-
-    @Value("${fint.provider.tracing:false}")
-    private boolean tracing;
 
     @Autowired
     private SseService sseService;
@@ -44,38 +30,9 @@ public class DownstreamSubscriber implements FintEventListener {
     @Autowired
     private ProviderProps providerProps;
 
-    private Path traceFile;
-    private ObjectMapper objectMapper;
-
-    @PostConstruct
-    public void init() throws IOException {
-        if (tracing) {
-            traceFile = Files.createTempFile("downstream", ".json");
-            Files.write(traceFile, "[\n{}".getBytes());
-            objectMapper = new ObjectMapper().disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
-            log.info("Tracing downstream events to {}", traceFile.toAbsolutePath());
-        }
-    }
-
-    @PreDestroy
-    public void shutdown() throws IOException {
-        if (tracing)
-            try (OutputStream os = Files.newOutputStream(traceFile, StandardOpenOption.APPEND, StandardOpenOption.SYNC)) {
-                os.write("\n]\n".getBytes());
-            }
-    }
-
     @Override
     public void accept(Event event) {
         log.debug("Event received: {}", event);
-        if (tracing) {
-            try (OutputStream os = Files.newOutputStream(traceFile, StandardOpenOption.APPEND, StandardOpenOption.SYNC)){
-                os.write(",\n".getBytes());
-                objectMapper.writeValue(os, event);
-            } catch (IOException e) {
-                log.info("Unable to trace event", e);
-            }
-        }
         if (event.isHealthCheck()) {
             event.addObject(new Health(Constants.COMPONENT, HealthStatus.RECEIVED_IN_PROVIDER_FROM_CONSUMER));
         }

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,19 +1,24 @@
-fint:
- hazelcast:
-  members: localhost
- provider:
-  test-mode: true
-  sse:
-   maxPoolSize: 10
-   queueCapacity: 0
- audit:
-  test-mode: true
- events:
-  test-mode: true
-  queue-endpoint-enabled: true
+spring:
+  application:
+    name: fint-provider
 
- springfox:
-  swagger-https: false
+fint:
+  hazelcast:
+    members: localhost
+  provider:
+    assets:
+      endpoint: https://admin.fintlabs.no/api/components/assets/administrasjon_personal
+    test-mode: true
+    sse:
+      maxPoolSize: 10
+      queueCapacity: 0
+  audit:
+    test-mode: true
+  events:
+    test-mode: true
+    queue-endpoint-enabled: true
+  springfox:
+    swagger-https: false
 
 server:
- port: 8081
+  port: 8081

--- a/src/test/groovy/no/fint/provider/events/admin/AdminControllerSpec.groovy
+++ b/src/test/groovy/no/fint/provider/events/admin/AdminControllerSpec.groovy
@@ -92,4 +92,20 @@ class AdminControllerSpec extends MockMvcSpecification {
         then:
         response.andExpect(status().isNotFound())
     }
+
+    def "Reject registering unknown orgId"() {
+        when:
+        def response = mockMvc.perform(post('/admin/orgIds/invalid.org').header(HeaderConstants.CLIENT, 'spock'))
+
+        then:
+        response.andExpect(status().is4xxClientError())
+        1 * adminService.register('invalid.org', 'spock') >> false
+
+        when:
+        def response2 = mockMvc.perform(post('/admin/orgIds/valid.org').header(HeaderConstants.CLIENT, 'spock'))
+
+        then:
+        response2.andExpect(status().is2xxSuccessful())
+        1 * adminService.register('valid.org', 'spock') >> true
+    }
 }

--- a/src/test/groovy/no/fint/provider/events/admin/AdminControllerSpec.groovy
+++ b/src/test/groovy/no/fint/provider/events/admin/AdminControllerSpec.groovy
@@ -2,6 +2,7 @@ package no.fint.provider.events.admin
 
 import no.fint.audit.plugin.mongo.MongoAuditEvent
 import no.fint.event.model.Event
+import no.fint.event.model.HeaderConstants
 import no.fint.events.FintEvents
 import no.fint.provider.events.subscriber.DownstreamSubscriber
 import no.fint.test.utils.MockMvcSpecification
@@ -39,17 +40,19 @@ class AdminControllerSpec extends MockMvcSpecification {
 
     def "POST new orgId"() {
         when:
-        def response = mockMvc.perform(post('/admin/orgIds/123'))
+        def response = mockMvc.perform(post('/admin/orgIds/123').header(HeaderConstants.CLIENT, 'spock'))
 
         then:
         1 * fintEvents.registerDownstreamListener('123', downstreamSubscriber)
+        1 * adminService.register('123', 'spock') >> true
+        1 * adminService.isRegistered('123') >> false
         response.andExpect(status().isCreated())
                 .andExpect(MockMvcResultMatchers.header().string(HttpHeaders.LOCATION, equalTo('http://localhost/admin/orgIds/123')))
     }
 
     def "POST new orgId, return bad request if orgId is already registered"() {
         when:
-        def response = mockMvc.perform(post('/admin/orgIds/123'))
+        def response = mockMvc.perform(post('/admin/orgIds/123').header(HeaderConstants.CLIENT, 'spock'))
 
         then:
         1 * adminService.isRegistered('123') >> true

--- a/src/test/groovy/no/fint/provider/events/admin/AdminControllerSpec.groovy
+++ b/src/test/groovy/no/fint/provider/events/admin/AdminControllerSpec.groovy
@@ -50,13 +50,13 @@ class AdminControllerSpec extends MockMvcSpecification {
                 .andExpect(MockMvcResultMatchers.header().string(HttpHeaders.LOCATION, equalTo('http://localhost/admin/orgIds/123')))
     }
 
-    def "POST new orgId, return bad request if orgId is already registered"() {
+    def "POST new orgId, return no content if orgId is already registered"() {
         when:
         def response = mockMvc.perform(post('/admin/orgIds/123').header(HeaderConstants.CLIENT, 'spock'))
 
         then:
         1 * adminService.isRegistered('123') >> true
-        response.andExpect(status().isBadRequest())
+        response.andExpect(status().isNoContent())
     }
 
     def "GET all registered orgIds"() {

--- a/src/test/groovy/no/fint/provider/events/admin/AdminDownstreamSubscriberSpec.groovy
+++ b/src/test/groovy/no/fint/provider/events/admin/AdminDownstreamSubscriberSpec.groovy
@@ -21,7 +21,7 @@ class AdminDownstreamSubscriberSpec extends Specification {
         subscriber.accept(event)
 
         then:
-        1 * adminService.register('rogfk.no')
+        1 * adminService.register('rogfk.no', 'test')
     }
 
     def "Do not process event with unknown action"() {
@@ -32,6 +32,6 @@ class AdminDownstreamSubscriberSpec extends Specification {
         subscriber.accept(event)
 
         then:
-        0 * adminService.register('rogfk.no')
+        0 * adminService.register('rogfk.no', 'test')
     }
 }

--- a/src/test/groovy/no/fint/provider/events/admin/AdminDownstreamSubscriberSpec.groovy
+++ b/src/test/groovy/no/fint/provider/events/admin/AdminDownstreamSubscriberSpec.groovy
@@ -2,15 +2,19 @@ package no.fint.provider.events.admin
 
 import no.fint.event.model.DefaultActions
 import no.fint.event.model.Event
+import no.fint.events.FintEvents
 import spock.lang.Specification
 
 class AdminDownstreamSubscriberSpec extends Specification {
     private AdminService adminService
+    private FintEvents fintEvents
     private AdminDownstreamSubscriber subscriber
 
     void setup() {
-        adminService = Mock(AdminService)
-        subscriber = new AdminDownstreamSubscriber(adminService: adminService)
+        adminService = Mock()
+        fintEvents = Mock()
+        subscriber = new AdminDownstreamSubscriber(adminService: adminService, fintEvents: fintEvents)
+        subscriber.init()
     }
 
     def "Receive register orgId"() {

--- a/src/test/groovy/no/fint/provider/events/admin/AdminServiceSpec.groovy
+++ b/src/test/groovy/no/fint/provider/events/admin/AdminServiceSpec.groovy
@@ -28,7 +28,7 @@ class AdminServiceSpec extends Specification {
         !registered
     }
 
-    def "Register new orgId once"() {
+    def "Register new orgId every time"() {
         given:
         def fintEvents = Mock(FintEvents)
         def adminService = new AdminService(fintEvents: fintEvents)
@@ -38,7 +38,7 @@ class AdminServiceSpec extends Specification {
         adminService.register('123', 'spock')
 
         then:
-        1 * fintEvents.sendUpstream(_ as Event)
+        2 * fintEvents.sendUpstream(_ as Event)
         adminService.isRegistered('123')
         adminService.getTimestamp('123') > 0
     }

--- a/src/test/groovy/no/fint/provider/events/admin/AdminServiceSpec.groovy
+++ b/src/test/groovy/no/fint/provider/events/admin/AdminServiceSpec.groovy
@@ -1,5 +1,7 @@
 package no.fint.provider.events.admin
 
+import no.fint.event.model.Event
+import no.fint.events.FintEvents
 import spock.lang.Specification
 
 class AdminServiceSpec extends Specification {
@@ -28,13 +30,15 @@ class AdminServiceSpec extends Specification {
 
     def "Register new orgId once"() {
         given:
-        def adminService = new AdminService()
+        def fintEvents = Mock(FintEvents)
+        def adminService = new AdminService(fintEvents: fintEvents)
 
         when:
-        adminService.register('123')
-        adminService.register('123')
+        adminService.register('123', 'spock')
+        adminService.register('123', 'spock')
 
         then:
+        1 * fintEvents.sendUpstream(_ as Event)
         adminService.isRegistered('123')
         adminService.getTimestamp('123') > 0
     }

--- a/src/test/groovy/no/fint/provider/events/sse/SseControllerSpec.groovy
+++ b/src/test/groovy/no/fint/provider/events/sse/SseControllerSpec.groovy
@@ -2,6 +2,7 @@ package no.fint.provider.events.sse
 
 import no.fint.event.model.HeaderConstants
 import no.fint.events.FintEvents
+import no.fint.provider.events.admin.AdminService
 import no.fint.provider.events.subscriber.DownstreamSubscriber
 import no.fint.test.utils.MockMvcSpecification
 import org.springframework.test.web.servlet.MockMvc
@@ -12,20 +13,23 @@ class SseControllerSpec extends MockMvcSpecification {
     private SseService sseService
     private FintEvents fintEvents
     private MockMvc mockMvc
+    private AdminService adminService
 
     void setup() {
-        sseService = Mock(SseService)
-        fintEvents = Mock(FintEvents)
+        sseService = Mock()
+        fintEvents = Mock()
+        adminService = Mock()
         downstreamSubscriber = Mock(DownstreamSubscriber)
-        controller = new SseController(sseService: sseService, fintEvents: fintEvents, downstreamSubscriber: downstreamSubscriber)
+        controller = new SseController(sseService: sseService, fintEvents: fintEvents, downstreamSubscriber: downstreamSubscriber, adminService: adminService)
         mockMvc = standaloneSetup(controller)
     }
 
     def "Subscribe to sse client"() {
         when:
-        def response = mockMvc.perform(get('/sse/123').header(HeaderConstants.ORG_ID, 'rogfk.no'))
+        def response = mockMvc.perform(get('/sse/123').header(HeaderConstants.ORG_ID, 'rogfk.no').header(HeaderConstants.CLIENT, 'spock'))
 
         then:
+        1 * adminService.register('rogfk.no', 'spock') >> true
         1 * sseService.subscribe('123', 'rogfk.no')
         1 * fintEvents.registerDownstreamListener('rogfk.no', downstreamSubscriber)
         response.andExpect(status().isOk())


### PR DESCRIPTION
Use admin portal endpoint to retrieve acceptable asset IDs.

When adapter using acceptable assetID connects, register assetID with consumer and start subscribing for events.

Relates to https://github.com/FINTprosjektet/fint-consumer-skeleton/pull/4

Fixes #8 
Fixes #18 